### PR TITLE
root - chore: upgrade TypeScript to 6 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tsd": "^0.33.0",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,13 +62,13 @@ importers:
         version: 0.33.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.18(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.18(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.1(@types/node@24.13.2)(terser@5.39.0)(tsx@4.22.4)(yaml@2.8.2))
@@ -2111,8 +2111,8 @@ packages:
     resolution: {integrity: sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==}
     engines: {node: '>=20'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4019,7 +4019,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(@swc/core@1.15.18(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(@swc/core@1.15.18(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -4041,7 +4041,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.18(@swc/helpers@0.5.17)
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -4068,7 +4068,7 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.1: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
     "compilerOptions": {
+      "ignoreDeprecations": "6.0",
       "target": "ESNext",
       "module": "ESNext",
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "strict": true,
       "esModuleInterop": true,
       "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
Upgrade TypeScript to the 6.0 major (the final JS-based release before the native 7.0).

## Versions
- `typescript` `5.9.3` → `6.0.3`

## Breaking notes
TS 6.0 turns several long-deprecated options into hard errors. Changes required here:
- **`moduleResolution: "node"` (node10) is deprecated** → migrated to `"bundler"`. This project builds with tsup (a bundler), and `bundler` pairs with the existing `module: "ESNext"`.
- **`baseUrl` deprecation** surfaced only during `tsup --dts` — it's injected by tsup's dts builder (rollup-plugin-dts), **not** present in our tsconfig. Added `ignoreDeprecations: "6.0"` to silence it. `tsc --noEmit` against our tsconfig is clean, so this is purely to tolerate the tooling-injected option; removable once tsup/rollup-plugin-dts stops injecting `baseUrl`.

No source changes; `dist/index.d.ts` output is byte-identical.

## Tests
- [x] `pnpm test` passes (lint + 46 tests, 100% coverage)
- [x] `pnpm build` passes (ESM + CJS + DTS)
- [x] `tsc --noEmit` clean under TS 6.0.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLospRvfUF2K4AttAjNS1x)_