### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 
@@ -33,7 +33,7 @@ jobs:
       run: pnpm test
       
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: jaredwray/fastify-fusion

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,10 +20,10 @@ jobs:
         node-version: ['22','24','26']
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions `uses:` references to their latest majors across the three workflows.

## Versions
- `actions/checkout` `v4` → `v6`
- `actions/setup-node` `v4` → `v6`
- `pnpm/action-setup` `v4` → `v6`
- `codecov/codecov-action` `v5` → `v7`

## Breaking notes
- All are major bumps (`(breaking)` title), but our usage is minimal: `setup-node` only gets `node-version`, `codecov-action` only uses `token`/`slug` (still valid in v7; the v5 deprecations were `file`→`files`), and `pnpm/action-setup` relies on the `packageManager` field with no `version` input (the documented "recommended usage" for v6).
- checkout/setup-node v6 run on the Node 24 action runtime, supported by `ubuntu-latest`.
- Pin style unchanged (`@vX`).

## Checks
- [x] All three workflow YAML files parse
- [ ] CI validates the upgraded actions (esp. `pnpm/action-setup@v6` reading `packageManager`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLospRvfUF2K4AttAjNS1x)_