### PR TITLE
root - chore: upgrade @fastify/rate-limit to 11 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",
-    "@fastify/rate-limit": "^10.3.0",
+    "@fastify/rate-limit": "^11.0.0",
     "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2
       '@fastify/rate-limit':
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: ^11.0.0
+        version: 11.0.0
       '@fastify/static':
         specifier: ^9.1.3
         version: 9.1.3
@@ -506,8 +506,8 @@ packages:
   '@fastify/proxy-addr@5.0.0':
     resolution: {integrity: sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==}
 
-  '@fastify/rate-limit@10.3.0':
-    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+  '@fastify/rate-limit@11.0.0':
+    resolution: {integrity: sha512-kCs+G59SitZw9TL/ekFe+MrzXk20dEp6zPAM8WEZjFl5Ubvv5ksTbEXYr4jGlBwWAKn78q+NFsj5CN75zXLjaw==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
@@ -2505,10 +2505,10 @@ snapshots:
       '@fastify/forwarded': 3.0.0
       ipaddr.js: 2.2.0
 
-  '@fastify/rate-limit@10.3.0':
+  '@fastify/rate-limit@11.0.0':
     dependencies:
       '@lukeed/ms': 2.0.2
-      fastify-plugin: 5.0.1
+      fastify-plugin: 5.1.0
       toad-cache: 3.7.0
 
   '@fastify/send@4.1.0':


### PR DESCRIPTION
## Summary
Upgrade the `@fastify/rate-limit` plugin to the v11 major (within the fastify 5 ecosystem).

## Versions
- `@fastify/rate-limit` `10.3.0` → `11.0.0`

## Breaking notes
- v11's only breaking change is **removal of deprecated types** (fastify/fastify-rate-limit#445). Our usage — the `FastifyRateLimitOptions` type plus `global` / `max` / `timeWindow` / `allowList` options — is unaffected; `pnpm build` (incl. `.d.ts`) is clean.
- No source changes. Fastify 5 peer is satisfied (5.3.2 installed; no peer warning on install).

## Tests
- [x] `pnpm test` passes (lint + 46 tests, 100% coverage)
- [x] `pnpm build` passes (ESM + CJS + DTS)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLospRvfUF2K4AttAjNS1x)_