### PR TITLE
root - chore: upgrade @fastify/swagger-ui to 6 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@fastify/rate-limit": "^11.0.0",
     "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",
-    "@fastify/swagger-ui": "^5.2.5",
+    "@fastify/swagger-ui": "^6.0.0",
     "@swc/core": "^1.15.18",
     "cacheable": "^2.3.3",
     "pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^9.7.0
         version: 9.7.0
       '@fastify/swagger-ui':
-        specifier: ^5.2.5
-        version: 5.2.5
+        specifier: ^6.0.0
+        version: 6.0.0
       '@swc/core':
         specifier: ^1.15.18
         version: 1.15.18(@swc/helpers@0.5.17)
@@ -512,14 +512,11 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.0.0':
-    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
-
   '@fastify/static@9.1.3':
     resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
 
-  '@fastify/swagger-ui@5.2.5':
-    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+  '@fastify/swagger-ui@6.0.0':
+    resolution: {integrity: sha512-L9c4CbXj3FnquqpCmn0IfbEeIqDUNi6QwXd23VhQj/bHEjNzDFIAy2W9I3prvSqM+mJWOElIa6uXROmcMDnfUA==}
 
   '@fastify/swagger@9.7.0':
     resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
@@ -2519,15 +2516,6 @@ snapshots:
       http-errors: 2.0.0
       mime: 3.0.0
 
-  '@fastify/static@9.0.0':
-    dependencies:
-      '@fastify/accept-negotiator': 2.0.1
-      '@fastify/send': 4.1.0
-      content-disposition: 1.0.1
-      fastify-plugin: 5.1.0
-      fastq: 1.19.1
-      glob: 13.0.6
-
   '@fastify/static@9.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
@@ -2537,9 +2525,9 @@ snapshots:
       fastq: 1.19.1
       glob: 13.0.6
 
-  '@fastify/swagger-ui@5.2.5':
+  '@fastify/swagger-ui@6.0.0':
     dependencies:
-      '@fastify/static': 9.0.0
+      '@fastify/static': 9.1.3
       fastify-plugin: 5.1.0
       openapi-types: 12.1.3
       rfdc: 1.4.1


### PR DESCRIPTION
## Summary
Upgrade the `@fastify/swagger-ui` plugin to the v6 major (within the fastify 5 ecosystem).

## Versions
- `@fastify/swagger-ui` `5.2.5` → `6.0.0`

## Breaking notes
- v6's breaking change is **removal of the deprecated `useUnsafeMarkdown` option** (plus internal type-tooling and bundled `swagger-ui-dist` bumps). We don't use `useUnsafeMarkdown`; our options (`routePrefix`, `uiConfig`, `uiHooks`, `staticCSP`, `transformSpecification`, `transformSpecificationClone`) are unaffected.
- No source changes. Peers satisfied: `fastify` 5.3.2, `@fastify/swagger` 9.7.0.

## Tests
- [x] `pnpm test` passes (lint + 46 tests, 100% coverage)
- [x] `pnpm build` passes (ESM + CJS + DTS)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLospRvfUF2K4AttAjNS1x)_