### PR TITLE
release: v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-fusion",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "type": "module",
   "packageManager": "pnpm@11.6.0",
   "description": "Fastify API framework with `best practices` and `plugins` fused together to make it easy to build and maintain your API.",


### PR DESCRIPTION
## Release summary
Adds a docula-generated project website and refreshes the bundled Fastify plugins and toolchain. Bumps `1.4.5` → `1.5.0` (minor: 1 `feat` + 12 `chore`).

> Single-package repo — no per-package table. The four "(breaking)" PRs (#75, #76, #78, #79) refer to **upstream** major bumps, not breaks in fastify-fusion's own API: each documents that the removed options/types were never used here, with no source changes and byte-identical `.d.ts` output. Hence minor, not major.

## fastify-fusion@1.5.0 — 2026-06-13

Adds a docula-generated project website and refreshes the bundled Fastify plugins and toolchain.

### Features
- add docula website generation with Cloudflare Pages deploy (d7821a0, #83)

  ```bash
  pnpm website:dev     # watch + serve the docs site locally
  pnpm website:build   # build the static site to site/dist
  ```

### Internal

**Bundled plugin updates** — no API change for fastify-fusion consumers; the upstream majors only dropped deprecated options/types this package never used:
- upgrade `@fastify/swagger-ui` 5.2.5 → 6.0.0 (a3924b4, #79)
- upgrade `@fastify/rate-limit` 10.3.0 → 11.0.0 (afddee4, #78)
- upgrade `@fastify/static` 9.0.0 → 9.1.3 (8007cbe, #77)
- upgrade `cacheable` 2.3.3 → 2.3.5 (5fc8da5, #81)
- upgrade `@swc/core` 1.15.18 → 1.15.41 (8f238c3, #80)

**Toolchain & CI**:
- upgrade TypeScript 5.9.3 → 6.0.3; switch `moduleResolution` to `bundler` (919b93c, #75)
- upgrade tsx 4.21.0 → 4.22.4 and pin `@types/node` to 24.13.2 (7af8e2b, #74)
- migrate to pnpm 11.6.0 via corepack; set `engines.node` to ^22.18.0 (b4c85fc, #73)
- upgrade code-quality deps: biome 2.4.6 → 2.5.0, vitest 4.0.18 → 4.1.8 (b16a86a, #73)
- upgrade GitHub Actions: checkout/setup-node v6, pnpm/action-setup v6, codecov v7 (09f939a, #76)
- source docula's GitHub token from the `GH_TOKEN` secret; clean `site/.cache` in `clean` (38b7585, fd92ca8, #83)

### Contributors
- @jaredwray (10 PRs; commits generated via Claude Code)

### Full List of Changes
- root - chore: migrate to pnpm 11 + corepack and upgrade code quality dependencies by @jaredwray in #73
- root - chore: upgrade tsx and pin @types/node to 24 by @jaredwray in #74
- root - chore: upgrade TypeScript to 6 (breaking) by @jaredwray in #75
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #76
- root - chore: upgrade @fastify/static by @jaredwray in #77
- root - chore: upgrade @fastify/rate-limit to 11 (breaking) by @jaredwray in #78
- root - chore: upgrade @fastify/swagger-ui to 6 (breaking) by @jaredwray in #79
- chore: upgrade @swc/core to 1.15.41 by @jaredwray in #80
- chore: upgrade cacheable to 2.3.5 by @jaredwray in #81
- feat: add docula website generation with Cloudflare deploy by @jaredwray in #83

**Full diff:** https://github.com/jaredwray/fastify-fusion/compare/v1.4.5...v1.5.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds (ESM + CJS + DTS)
- [x] `pnpm test:ci` passes locally — 46 tests, 100% coverage
- [x] No uncommitted changes outside the version bump (no `CHANGELOG.md` in repo)

## Post-merge
- Merge, then create a GitHub Release at tag `v1.5.0` — the `release.yaml` workflow publishes to npm on release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrX5aVJx7GJpcn3zC58LK)_