### PR TITLE
ci: migrate release to npm OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -20,20 +21,19 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       run: pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test
 
-    - name: Publish
-      run: |
-        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        npm publish --ignore-scripts
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Update npm
+      run: npm install -g npm@latest
 
+    - name: Publish
+      run: npm publish --provenance --ignore-scripts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,5 @@ jobs:
     - name: Testing
       run: pnpm test
 
-    - name: Update npm
-      run: npm install -g npm@latest
-
     - name: Publish
-      run: npm publish --provenance --ignore-scripts
+      run: pnpm publish --provenance --no-git-checks --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -32,6 +32,14 @@
   ],
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/fastify-fusion.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jaredwray/fastify-fusion/issues"
+  },
+  "homepage": "https://github.com/jaredwray/fastify-fusion#readme",
   "engines": {
     "node": "^22.18.0"
   },


### PR DESCRIPTION
## Summary

Migrates the `release.yaml` workflow from token-based npm publishing to [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) with build provenance.

## Changes

- **Removed `NPM_TOKEN`**: no more long-lived npm secret. Drops the manual `npm config set //registry.npmjs.org/:_authToken` step.
- **Added `id-token: write` permission**: required so GitHub Actions can mint the OIDC token npm exchanges for short-lived publish credentials.
- **Configured the npm registry** via `registry-url` on `actions/setup-node` so the OIDC flow targets npmjs.org.
- **Upgraded npm** (`npm install -g npm@latest`) to ensure a version that supports OIDC trusted publishing (npm 11.5.1+); Node 24 ships with an older npm by default.
- **Publish with provenance**: `npm publish --provenance --ignore-scripts` generates and attaches a signed provenance attestation.

## Before publishing works

The package must be configured for trusted publishing on npmjs.com: under the package's **Settings → Trusted Publisher**, add this repository and the `release` workflow. Once configured, no token is needed.

https://claude.ai/code/session_01TJgNKZEBHXbgSHiSfNmXw7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJgNKZEBHXbgSHiSfNmXw7)_