### PR TITLE
ci: allow wrangler build scripts (sharp, workerd) for Pages deploy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,7 @@ minimumReleaseAge: 1440
 allowBuilds:
   '@swc/core': true
   esbuild: true
+  sharp: true
   unrs-resolver: true
   vue-demi: true
+  workerd: true


### PR DESCRIPTION
## Problem

The `deploy-site` workflow fails at the **Publish to Cloudflare Pages** step:

```
📥 Installing Wrangler
  pnpm add wrangler@4
  ...
  + wrangler 4.100.0
  [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, workerd@1.20260611.1
  Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: The process '.../pnpm' failed with exit code 1
Error: 🚨 Action failed
```

## Root cause

`cloudflare/wrangler-action@v4` doesn't find a compatible Wrangler, so it runs `pnpm add wrangler@4` **inside the repo**. Wrangler pulls in `sharp` and `workerd`, both of which have install/build scripts.

Under pnpm 11's strict supply-chain policy, any package with a build script that is **not** listed in `allowBuilds` is ignored — and for `pnpm add`, that ignore is a **hard error** (`ERR_PNPM_IGNORED_BUILDS`, exit 1), which fails the action.

## Fix

Add `sharp` and `workerd` to `allowBuilds` in `pnpm-workspace.yaml` so their install scripts are permitted when the action installs Wrangler.

## Verification

Reproduced and confirmed the fix locally with pnpm 11.6.0 (the pinned `packageManager`):

| `pnpm-workspace.yaml` | `pnpm add wrangler@4` |
|---|---|
| before (no `sharp`/`workerd`) | ❌ `ERR_PNPM_IGNORED_BUILDS`, exit 1 |
| after (full repo allow-list) | ✅ esbuild + sharp + workerd build, `+ wrangler 4.100.0`, exit 0 |

Also verified that `allowBuilds` (not the legacy `onlyBuiltDependencies`) is the key actually honored by pnpm 11.6.0, so the additions take effect.

https://claude.ai/code/session_01FqYqdS6d7TtHDA9PNUDZK3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqYqdS6d7TtHDA9PNUDZK3)_