### PR TITLE
ci: pass --commit-dirty=true to Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -38,4 +38,4 @@ jobs:
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy site/dist --project-name=fastify-fusion --branch=main
+        command: pages deploy site/dist --project-name=fastify-fusion --branch=main --commit-dirty=true


### PR DESCRIPTION
## Follow-up to #86

#86 fixed the Wrangler **install** failure (`ERR_PNPM_IGNORED_BUILDS`). With that merged, the `deploy-site` workflow now installs Wrangler 4.100.0 cleanly and reaches the actual deploy command. The remaining deploy log shows a non-fatal warning:

```
▲ [WARNING] Warning: Your working directory is a git repo and has uncommitted changes
  To silence this warning, pass in --commit-dirty=true
```

This happens because `docula build` writes the gitignored `site/dist` output, leaving the working tree "dirty" when `wrangler pages deploy` runs.

## Change

Append `--commit-dirty=true` to the `pages deploy` command so the warning is silenced and the deploy is unambiguous about deploying the freshly built (uncommitted) `site/dist`.

## Note on the current deploy failure

The latest run also fails with `Project not found [code: 8000007]` for the Pages project `fastify-fusion`. That is a **Cloudflare-side** matter (the Pages project needs to exist in the account) and is not addressed by this repo change — it's tracked separately with the maintainer.

https://claude.ai/code/session_01FqYqdS6d7TtHDA9PNUDZK3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqYqdS6d7TtHDA9PNUDZK3)_