### PR TITLE
root - chore: set engines.node to &gt;=22.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/jaredwray/fastify-fusion#readme",
   "engines": {
-    "node": "^22.18.0"
+    "node": ">=22.19.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A for a metadata change (no source change); the existing suite still passes at 100% coverage.

**What kind of change does this PR introduce?**

Chore — metadata fix. Follow-up to #91.

## Summary
`docula@2.2.0` (merged in #91) and its transitive `undici@8.4.1` require Node `^22.19.0 || >=24.0.0`, but `engines.node` still declared `^22.18.0`. Review on #91 (Gemini, Codex) flagged the mismatch.

## Change
- `engines.node` `^22.18.0` → `>=22.19.0`

`>=22.19.0` satisfies docula's requirement and covers Node 22.19+, 24, and 26 — aligning `engines.node` with `.nvmrc` (24) and the CI matrix (22/24/26). The previous `^22.x`-only range excluded 24/26 despite the project developing and testing on them.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — biome lint + vitest, 100% coverage
- [x] `pnpm install` reports no engine warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGpDFpy4VSQjdyJtqS5jcv)_