### PR TITLE
root - chore: upgrade @fastify/static to v10 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@fastify/cors": "^11.3.0",
     "@fastify/helmet": "^13.1.0",
     "@fastify/rate-limit": "^11.1.0",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.0",
     "@fastify/swagger": "^9.8.0",
     "@fastify/swagger-ui": "^6.1.0",
     "@swc/core": "^1.15.43",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       '@fastify/static':
-        specifier: ^9.1.3
-        version: 9.1.3
+        specifier: ^10.1.0
+        version: 10.1.0
       '@fastify/swagger':
         specifier: ^9.8.0
         version: 9.8.0
@@ -553,6 +553,9 @@ packages:
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@10.1.0':
+    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
 
   '@fastify/static@9.1.3':
     resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
@@ -1390,6 +1393,10 @@ packages:
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -3636,6 +3643,16 @@ snapshots:
       http-errors: 2.0.0
       mime: 3.0.0
 
+  '@fastify/static@10.1.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.1.0
+      '@fastify/send': 4.1.0
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
+      fastq: 1.19.1
+      glob: 13.0.6
+
   '@fastify/static@9.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
@@ -4327,6 +4344,8 @@ snapshots:
   content-disposition@0.5.2: {}
 
   content-disposition@1.0.1: {}
+
+  content-disposition@2.0.1: {}
 
   convert-source-map@2.0.0: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A for a dependency bump (no source change); the existing static-serving tests still pass at 100% coverage.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime-phase fastify-ecosystem **breaking major**, shipped in its own PR (separate from the plugin minor group in #94).

## Versions
- `@fastify/static` 9.1.3 → 10.1.0 *(major)*

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 46 tests, 100% coverage, including the `test/fixtures` static-serving tests that exercise this plugin

## Breaking notes
`@fastify/static` v10 is a major bump, hence the `(breaking)` label. This project's usage (`src/static.ts`) registers it with only `root`, `prefix`, and `decorateReply: false` — all unchanged in v10 — so **no code changes were required**. The static registration and file-serving tests pass unchanged, and the PR's CI re-verifies across the Node 22/24/26 matrix.

---
This is the final dependency-management PR. After it, the only remaining outdated packages are the two documented deferrals: `typescript` 6→7 (tsup/rollup-plugin-dts can't emit `.d.ts` against the TS7 native-port API yet) and `@types/node` 26 (capped at the `.nvmrc` Node major, 24).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGpDFpy4VSQjdyJtqS5jcv)_