### PR TITLE
fastify-fusion - chore: upgrade @fastify/static

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@fastify/cors": "^11.3.0",
     "@fastify/helmet": "^13.1.0",
     "@fastify/rate-limit": "^11.1.0",
-    "@fastify/static": "^10.1.0",
+    "@fastify/static": "^10.1.3",
     "@fastify/swagger": "^9.8.0",
     "@fastify/swagger-ui": "^6.1.0",
     "@swc/core": "^1.15.43",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       '@fastify/static':
-        specifier: ^10.1.0
-        version: 10.1.0
+        specifier: ^10.1.3
+        version: 10.1.3
       '@fastify/swagger':
         specifier: ^9.8.0
         version: 9.8.0
@@ -554,8 +554,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@10.1.0':
-    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
+  '@fastify/static@10.1.3':
+    resolution: {integrity: sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==}
 
   '@fastify/static@9.1.3':
     resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
@@ -3643,7 +3643,7 @@ snapshots:
       http-errors: 2.0.0
       mime: 3.0.0
 
-  '@fastify/static@10.1.0':
+  '@fastify/static@10.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/error': 4.1.0


### PR DESCRIPTION
## Summary

Upgrade `@fastify/static` from 10.1.0 to 10.1.3.

## Why

Versions through 10.1.1 are affected by [GHSA-8pvw-jcv7-9cmj](https://github.com/fastify/fastify-static/security/advisories/GHSA-8pvw-jcv7-9cmj), an authorization bypass involving non-canonical URL paths. Version 10.1.2 introduced the fix, and 10.1.3 is the current patch release.

## Impact

Applications using `allowedPath` as a security boundary receive the upstream path-normalization fix. No source-code changes are required in fastify-fusion.

## Changes

- Upgrade `@fastify/static` from 10.1.0 to 10.1.3
- Refresh the corresponding pnpm lockfile entries

## Verification

- [x] `pnpm test` passes (46 tests, 100% coverage)
- [x] `pnpm build` passes